### PR TITLE
fix: correct argument encoding

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -56,11 +56,11 @@ namespace repeater
                     null,
                     DateTimeOffset.UtcNow
                 );
-                var txHex = ByteUtil.Hex(tx.Serialize(true));
+                var txBase64 = Convert.ToBase64String(tx.Serialize(true));
 
                 var txRequest = new GraphQLRequest
                 {
-                    Query = $"mutation {{ stageTx(payload: \"{txHex}\") }}",
+                    Query = $"mutation {{ stageTx(payload: \"{txBase64}\") }}",
                 };
                 var res = await gqlClient.SendMutationAsync<dynamic>(txRequest);
                 Console.WriteLine(res.Data.stageTx);


### PR DESCRIPTION
Since https://github.com/planetarium/NineChronicles.Headless/pull/552, `stageTx` mutation became to receive base64 encoded `payload`, not hexadecimal string.

This pull request applies the change.